### PR TITLE
Fix for when the root element is null but we still have a nested scheme

### DIFF
--- a/src/parseFormToMutation.test.ts
+++ b/src/parseFormToMutation.test.ts
@@ -16,6 +16,25 @@ test('parseFormToMutation - basic', () => {
   });
 });
 
+test('parseFormToMutation - Nested Scheme with null root', () => {
+  const values = {
+    name: 'Summer season',
+    organization: null
+  };
+  const scheme = {
+    organization: {
+      __format: create,
+      address: create
+    }
+  };
+  const formatted = parseFormToMutation(values, scheme);
+
+  expect(formatted).toEqual({
+    name: 'Summer season',
+    organization: null
+  });
+});
+
 test('parseFormToMutation - advanced', () => {
   const values = {
     categories: [

--- a/src/parseFormToMutation.ts
+++ b/src/parseFormToMutation.ts
@@ -40,11 +40,11 @@ export function parseFormToMutation(values: object, scheme: Scheme): object {
             currentValue.forEach(value =>
               traverseScheme(value, action as Scheme, key, _values)
             );
-          } else {
+          } else if (currentValue) {
             applyParentAction(currentValue, action as Scheme, key, _values);
             traverseScheme(currentValue, action as Scheme, key, _values);
           }
-        } else {
+        } else if (_values) {
           _values[key] = (action as ActionFn)(currentValue);
         }
       });


### PR DESCRIPTION
This is a PR to fix this [issue](https://github.com/Volst/graphql-form-helpers/issues/8)